### PR TITLE
Remove caching

### DIFF
--- a/grains/ec2_info.py
+++ b/grains/ec2_info.py
@@ -9,7 +9,6 @@ import ast
 import logging
 import httplib
 import socket
-import pickle
 import os
 
 # Set up logging
@@ -99,21 +98,5 @@ def ec2_info():
         LOG.info("Could not read EC2 data (IOError): %s" % (serr))
         return {}
 
-def cached_ec2_info():
-    """
-    Cache result on the disk, this can speed up a lot this script when running
-    outside Amazon EC2 and with firewall that drop packets.
-    """
-    cache_filename = os.path.join(__opts__['cachedir'], 'ec2_info.pickle')
-    try:
-        with open(cache_filename, 'rb') as file_handler:
-            data = pickle.load(file_handler)
-        return data
-    except IOError:
-        data = ec2_info()
-        with open(cache_filename, 'wb') as file_handler:
-            pickle.dump(data, file_handler)
-        return data
-
 if __name__ == "__main__":
-    print cached_ec2_info()
+    print ec2_info()


### PR DESCRIPTION
If you take an Amazon instance and stop it (not terminate).
And you start it, it's IP change, but this cache file is not invalidated.

As I don't have a cross-platform way to get the OS uptime (maybe it's available in psutil) and remove the file if it's older than the uptime, I prefer to remove this code to make sure no one else hit this issue.
