### PR TITLE
tomcat manager module and state

### DIFF
--- a/modules/tomcat_manager.py
+++ b/modules/tomcat_manager.py
@@ -343,6 +343,8 @@ def deploy_war(war, context, force='no', url='http://localhost:8080/manager', en
         except Exception:
             return 'FAIL - could not cache the war file'
     
+    context = '{0}##{1}'.format(context, war.split('/')[-1].replace('.war',''))
+    
     # Prepare options
     opts = {
         'war': 'file:{0}'.format(tempfile),


### PR DESCRIPTION
Hi Guys,

This is a module/state to manage tomcat webapps via the manager webapp.
I've being relying heavily on webapps versions for this.
http://tomcat.apache.org/tomcat-7.0-doc/config/context.html#Naming

Currently supporting only one version per context and support deploy of war files,
But this could be extended very easily to support context.xml & directory deployment.

I'll be happy to hear your thoughts about this module.
