### PR TITLE
Make ec2_info.py less naive

### DIFF
--- a/grains/ec2_info.py
+++ b/grains/ec2_info.py
@@ -39,7 +39,11 @@ def _get_ec2_hostinfo(path="", data={}):
     """
     for line in _call_aws("/latest/meta-data/%s" % path).split("\n"):
         if line[-1] != "/":
-            data["ec2_" + line] = _call_aws("/latest/meta-data/%s" % (path + line))
+            call_response = _call_aws("/latest/meta-data/%s" % (path + line))
+            if call_response is not None:
+                data["ec2_" + path.replace("/", "_") + line] = call_response
+            else:
+                data["ec2_" + path.replace("/", "_")[:-1]] = line
         else:
             _get_ec2_hostinfo(path + line, data=data)
 


### PR DESCRIPTION
The calls to the ec2 meta-data service were causing collisions with themselves because of the naive storage, it now takes the whole URL path in order to create the keys for the dict.

In addition it was failing to properly catch some useful values properly, like the public keys, which would get stored as {'ec2_0=keyname': None}, this has been corrected by checking for the return value of _call_aws().

Keep in mind this still uses a naive and quick method for mapping the meta-data service to a dict, but it's still very useful.
