### PR TITLE
support case where env is None

### DIFF
--- a/modules/rabbitmq_plugins.py
+++ b/modules/rabbitmq_plugins.py
@@ -24,9 +24,10 @@ def __virtual__():
 
 def _convert_env(env):
     output = {}
-    for var in env.split():
-        k, v = var.split('=')
-        output[k] = v
+    if env:
+        for var in env.split():
+            k, v = var.split('=')
+            output[k] = v
     return output
 
 def _rabbitmq_plugins(command, runas=None, env=()):


### PR DESCRIPTION
when I use this module I get an exception 

```
State: - rabbitmq_plugins
Name:      rabbitmq_management
Function:  enabled
    Result:    False
    Comment:   An exception occurred in this state: Traceback (most recent call last):
```

  File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1280, in call
    ret = self.states[cdata['full']](*cdata['args'])
  File "/var/cache/salt/minion/extmods/states/rabbitmq_plugins.py", line 65, in enabled
    plugins = **salt**['rabbitmq_plugins.list'](env=env, runas=runas)
  File "/var/cache/salt/minion/extmods/modules/rabbitmq_plugins.py", line 52, in list
    env=_convert_env(env))
  File "/var/cache/salt/minion/extmods/modules/rabbitmq_plugins.py", line 27, in _convert_env
    for var in env.split():
AttributeError: 'NoneType' object has no attribute 'split'
