### PR TITLE
Rename yumpkg to yumpkg_api and refactor

### DIFF
--- a/modules/yumpkg_api.py
+++ b/modules/yumpkg_api.py
@@ -33,13 +33,12 @@ account when configuring your syslog daemon.
 import copy
 import fnmatch
 import logging
-import os
 import re
 import yaml
 
 # Import salt libs
 import salt.utils
-from salt.exceptions import CommandExecutionError, SaltInvocationError
+from salt.exceptions import CommandExecutionError
 from salt.utils import namespaced_function as _namespaced_function
 from salt.modules.yumpkg5 import (
     _parse_repo_file, list_repos, mod_repo, get_repo, del_repo,


### PR DESCRIPTION
This takes the newly refactored yum API-based pkg frontend and renames
it to yumpkg_api, and hides it behind a config option.
