### PR TITLE
only requires DescribeTags permission

### DIFF
--- a/grains/ec2_tags.py
+++ b/grains/ec2_tags.py
@@ -101,15 +101,10 @@ def ec2_tags():
 
     tags = {}
     try:
-        #reservation = conn.get_all_instances(instance_ids=[ instance_id ])[0]
-        #instance = reservation.instances[0]
-        reservations = conn.get_all_instances()
-        instances = [i for r in reservations for i in r.instances]
-
-        for instance in instances:
-            if instance.__dict__['id'] == instance_id:
-                tags = instance.tags
-                break
+        _tags = conn.get_all_tags(filters={'resource-type': 'instance',
+                'resource-id': instance_id})
+        for tag in _tags:
+            tags[tag.name] = tag.value
     except IndexError, e:
         log.error("Couldn't retrieve instance information: %s", e)
         return None


### PR DESCRIPTION
The previous version required more privileges. Now it only requires DescribeTags. boto.ec2.get_all_tags() has been around since 2010.
