### PR TITLE
Added iscsitarget.py and iscsistorage.py to modules

### DIFF
--- a/modules/iscsistorage.py
+++ b/modules/iscsistorage.py
@@ -1,15 +1,15 @@
 """
-A module to configure iSCSI shares in iSCSI storage pools managed by
-libvirt.
+A module to push the configuration for iSCSI shares to front end servers using 
+storage pools manged by libvirt.
 
 :maintainer: Brent Lambert <brent@enpraxis.net>
 :maturity: new
 :depends: libvirt python API
 :platform: all
-:configuration: Default configuration is specified as follows::
+:configuration: Default minion configuration is specified as follows::
     
-    iscsistorage.iqn_base: 2007-12.net.enpraxis
-    iscsistorage.sip: 192.168.5.67
+    iscsistorage.iqn_base: 2000-01.com.mydomain
+    iscsistorage.sip: <IP of your SAN>
     iscsistorage.sport: 3260
     
 """
@@ -45,6 +45,39 @@ def _get_option(opt, kwargs):
 
 def add(name, **kwargs):
     """
+    Add an iSCSI share to a front end server's storage pool for use 
+    as a storage volume for a virtual server. The iSCSI target should
+    already be created on the SAN and be ready to go.
+
+    You can (and probably should) mount the target as a storage pool on 
+    all front end servers to facilitate live migration of virtual machines 
+    using the volume on your SAN. Note that you should never launch multipe 
+    virtual machines on different front end servers for the same target on 
+    the SAN, or very bad things will happen.
+
+    name
+      Name of the iSCSI target minus the IQN Base (required)
+
+    iqn_base
+      Override the iqn_base parameter specified in the minion config 
+      file (optional)
+
+    sip
+      Override the sip parameter specified in the minion config file
+      (optional)
+
+    sport
+      Override the sport parameter specified in the minion config file
+      (optional)
+
+    CLI example::
+
+        salt front* iscsistorage.add mytarget
+
+        salt front* iscsistorage.add mytarget iqn_base=iqn.2000.01.com.altdomain
+
+       salt front* iscsistorage.add mytarget sip=192.168.2.1 sport=43260
+
     """
     iqn_base = _get_option('iqn_base', kwargs)
     niqn = '{0}:{1}'.format(iqn_base, name)
@@ -59,7 +92,7 @@ def add(name, **kwargs):
             npool.create(0)
             msg = 'Success'
         else:
-            msg = 'Error: (libvirt) could not create stoage pool'
+            msg = 'Error: (libvirt) could not create storage pool'
     else:
          msg = 'Error: (libvirt) could not connect'    
 
@@ -68,6 +101,19 @@ def add(name, **kwargs):
 
 def delete(name, **kwargs):
     """
+    Delete a storage pool from a front end server using libvirt.
+    This will unmount the iSCSI Target from the front end server, but
+    will not delete the iSCSI share from the SAN.
+
+    name
+      Name of iSCSI target derived from the IQN minus the IQN Base
+      (required)
+
+
+    CLI Example::
+ 
+        salt front* iscsistorage.delete mytarget
+
     """
     conn = libvirt.open(connect)
     if conn:


### PR DESCRIPTION
Added two modules for using iSCSI targets. One (iscsitarget.py) for creating iSCSI targets on a server running LVM and IET (http://iscsitarget.sourceforge.net/), and one for mounting the iSCSI target on front end servers using libvirt storage pools. These two modules when used with a server set up as a back end SAN and a front end server configured as a libvirt hypervisor, make it possible to manage iSCSI shares for virtual machine deployment. iSCSI shares can be mounted as storage pools on multiple front end hypervisors, and then using libvirt or salt-virt can perform live migrations of virtual machines from one front end server to another all controlled by salt.

Feel free to make any modifications or alterations as you see fit.
