### PR TITLE
Add grains that pull metadata from GCE metadata servers

### DIFF
--- a/grains/gce.py
+++ b/grains/gce.py
@@ -1,0 +1,35 @@
+# get info from gce metadata and put it into grains store
+# Requires Python 2.6 or higher or the standalone json module
+
+import httplib
+import json
+
+def gce_ext_ip():
+    """
+    Fetch the public IP address for this instance from Google's metadata
+    servers.
+    """
+    h = httplib.HTTPConnection('metadata')
+    h.request('GET',
+        '/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip',
+        ' ', {'X-Google-Metadata-Request': 'True'})
+    rsp = h.getresponse()
+    return {'pub_fqdn_ipv4': rsp.read()}
+
+def gce_tags():
+    """
+    Fetch the instance's tags from Google's metadata servers.
+
+    It fills in tags and roles in the dictionary to allow interoperation with
+    formulas that key off of the roles grain.
+    """
+    h = httplib.HTTPConnection('metadata')
+    h.request('GET',
+        '/computeMetadata/v1/instance/tags', ' ', {'X-Google-Metadata-Request': 'True'})
+    rsp = h.getresponse()
+    tags = json.loads(rsp.read())
+    return {'tags': tags, 'roles': tags}
+
+if __name__ == '__main__':
+    print gce_ext_ip()
+    print gce_tags()


### PR DESCRIPTION
Google exposes a certain amount of instance metadata via some local IPs. Take
the info from that interface and put it into grains to allow easy access from
inside salt states, etc.
