### PR TITLE
Syntax error in ec2_tags gain, big cleanup and merge in ec2_tag_roles functionality

### DIFF
--- a/grains/ec2_tags.py
+++ b/grains/ec2_tags.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """
-ec2_tags.py - exports all EC2 tags in an 'ec2_tags' grain
+ec2_tags.py - exports all EC2 tags in an 'ec2_tags' grain and splits 'Role' tag
+              into a list on 'ec2_roles' grain.
 
 To use it:
 
@@ -21,7 +22,8 @@ To use it:
   4. Test it
 
     $ salt '*' saltutil.sync_grains
-    $ salt '*' grains.get tags
+    $ salt '*' grains.get ec2_tags
+    $ salt '*' grains.get ec2_roles
 
 Author: Emil Stenqvist <emsten@gmail.com>
 Licensed under Apache License (https://raw.github.com/saltstack/salt/develop/LICENSE)
@@ -44,20 +46,18 @@ AWS_CREDENTIALS = {
     'secret_key': None,
 }
 
+
 def _get_instance_info():
     identity = boto.utils.get_instance_identity()['document']
     return (identity['instanceId'], identity['region'])
 
+
 def _on_ec2():
     m = boto.utils.get_instance_metadata(timeout=0.1, num_retries=1)
-    return len(m.keys()) > 0
+    return bool(m)
+
 
 def _get_credentials():
-
-    # 1. Get from static AWS_CREDENTIALS
-    if AWS_CREDENTIALS['access_key'] and AWS_CREDENTIALS['secret_key']:
-        return AWS_CREDENTIALS
-
     # 2. Get from minion config
     if '__opts__' in globals():
         conf = __opts__.get('ec2_tags', {})
@@ -69,53 +69,60 @@ def _get_credentials():
     access_key = os.environ.get('AWS_ACCESS_KEY') or os.environ.get('AWS_ACCESS_KEY_ID')
     secret_key = os.environ.get('AWS_SECRET_KEY') or os.environ.get('AWS_SECRET_ACCESS_KEY')
     if access_key and secret_key:
-        return {
-                'access_key': access_key,
-                'secret_key': secret_key,}
+        return dict(access_key=access_key, secret_key=secret_key)
 
-    # 4. Leave as None to use roles
+    # 1. Get from static AWS_CREDENTIALS (Leave as None to use IAM role)
     return AWS_CREDENTIALS
 
-def ec2_tags():
 
+def ec2_tags():
     boto_version = StrictVersion(boto.__version__)
     required_boto_version = StrictVersion('2.8.0')
     if boto_version < required_boto_version:
-        log.error("%s: installed boto version %s < %s, can't find ec2_tags",
-                __name__, boto_version, required_boto_version)
+        log.error("Installed boto version %s < %s, can't find ec2_tags",
+                  boto_version, required_boto_version)
         return None
 
     if not _on_ec2():
-        log.info("%s: not an EC2 instance, skipping", __name__)
+        log.info("Not an EC2 instance, skipping")
         return None
 
     (instance_id, region) = _get_instance_info()
     credentials = _get_credentials()
 
     # Connect to EC2 and parse the Roles tags for this instance
-    try:
-        conn = boto.ec2.connect_to_region(region,
-                aws_access_key_id=credentials['access_key'],
-                aws_secret_access_key=credentials['secret_key'])
-    except:
-        if not (credentials['access_key'] and credentials['secret_key']):
-            log.error("%s: no AWS credentials found, see documentation for how to provide them.", __name__)
-            return None
-        else:
-            log.error("%s: invalid AWS credentials found, see documentation for how to provide them.", __name__)
-            return None
-
-    tags = {}
-    try:
-        _tags = conn.get_all_tags(filters={'resource-type': 'instance',
-                'resource-id': instance_id})
-        for tag in _tags:
-            tags[tag.name] = tag.value
-    except IndexError, e:
-        log.error("Couldn't retrieve instance information: %s", e)
+    if not (credentials['access_key'] and credentials['secret_key']):
+        log.error("No AWS credentials found, see documentation for how to provide them.")
         return None
 
-    return { 'ec2_tags': tags }
+    try:
+        conn = boto.ec2.connect_to_region(
+            region,
+            aws_access_key_id=credentials['access_key'],
+            aws_secret_access_key=credentials['secret_key'],
+        )
+    except Exception, e:
+        log.error("Could not connect to AWS using specified credentials: %s", e)
+        return None
+
+    ec2_tags = {}
+    try:
+        tags = conn.get_all_tags(filters={'resource-type': 'instance',
+                                          'resource-id': instance_id})
+        for tag in tags:
+            ec2_tags[tag.name] = tag.value
+    except IndexError, e:
+        log.error("Couldn't retrieve instance tags: %s", e)
+        return None
+
+    ret = dict(ec2_tags=ec2_tags)
+
+    # Provide ec2_tags_roles functionality
+    if 'Roles' in ec2_tags:
+        ret['ec2_roles'] = tags['Roles'].split(',')
+
+    return ret
+
 
 if __name__ == '__main__':
     print ec2_tags()

--- a/grains/ec2_tags.py
+++ b/grains/ec2_tags.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 ec2_tags.py - exports all EC2 tags in an 'ec2_tags' grain
 

--- a/grains/ec2_tags.py
+++ b/grains/ec2_tags.py
@@ -59,15 +59,11 @@ def _get_credentials():
         return AWS_CREDENTIALS
 
     # 2. Get from minion config
-    if "aws" in __opts__.get['ec2_tags']:
-        try:
-            aws = __opts__.get['ec2_tags']['aws']
-            return {
-                'access_key': aws['access_key'],
-                'secret_key': aws['secret_key']
-            }
-        except (KeyError, NameError):
-            pass
+    if '__opts__' in globals():
+        conf = __opts__.get('ec2_tags', {})
+        aws = conf.get('aws', {})
+        if aws.get('access_key') and aws.get('secret_key'):
+            return aws
 
     # 3. Get from environment
     access_key = os.environ.get('AWS_ACCESS_KEY') or os.environ.get('AWS_ACCESS_KEY_ID')


### PR DESCRIPTION
This does alter the order of preferred configuration to be a bit more overridable, namely environment variables or salt-minion configuration override what is specified in the file itself, providing a default. Before the locally specified configuration was the top priority, preventing any ability to override them.

This also fixes running the grain outside of Salt to test by checking for dunder dict presence before accessing them.