### PR TITLE
Fix detection of existing non-root vdir

### DIFF
--- a/states/iis.py
+++ b/states/iis.py
@@ -333,5 +333,7 @@ def vdir_present(name, app, settings=None):
 
     if name == '/' and '/' not in app[0:-1]:
         return _resource_present('vdir', app, settings, app)
-    return _resource_present('vdir', app, settings, app+name)
+        
+    alt_name = app.rstrip('/') + name
+    return _resource_present('vdir', app, settings, alt_name)
 


### PR DESCRIPTION
The following state fails when the vdir already exists because the straight concatenation of the app+name results in double slashes which are not found when checking for an existing vdir, e.g. it is looking for "Default Web Site//test" when the real id is "Default Web Site/test".

    test.vdir:
      iis.vdir_present:
        - name: /test
        - app: Default Web Site/
        - settings:
            physicalPath: C:\inetpub\wwwroot\test

Here is the debug output from the minion:

    2015-03-02 10:46:13,365 [salt.template    ][DEBUG   ] Rendered data from file: c:\salt\var\cache\salt\minion\files\base\test.sls:
    test.vdir:
      iis.vdir_present:
        - name: /test
        - app: Default Web Site/
    2015-03-02 10:46:13,365 [salt.loaded.int.render.yaml][DEBUG   ] Results of YAML rendering: 
    OrderedDict([('test.vdir', OrderedDict([('iis.vdir_present', [OrderedDict([('name', '/test')]), OrderedDict([('app', 'Default Web Site/')])])]))])
    2015-03-02 10:46:13,365 [salt.state       ][INFO    ] Running state [/test] at time 10:46:13.365000
    2015-03-02 10:46:13,365 [salt.state       ][INFO    ] Executing state iis.vdir_present for /test
    2015-03-02 10:46:13,365 [salt.loaded.int.module.cmdmod][INFO    ] Executing command '"C:\\Windows\\System32\\inetsrv\\appcmd.exe" list VDIR' in directory 'C:\\Users\\svc_buildbambi'
    2015-03-02 10:46:13,412 [salt.loaded.int.module.cmdmod][DEBUG   ] stdout: VDIR "Default Web Site/" (physicalPath:C:\inetpub\wwwroot)
    VDIR "Default Web Site/test" (physicalPath:C:\inetpub\wwwroot\test)
    2015-03-02 10:46:13,412 [salt.loaded.ext.module.iis][DEBUG   ] settings: '{0}'
    2015-03-02 10:46:13,412 [salt.loaded.int.module.cmdmod][INFO    ] Executing command '"C:\\Windows\\System32\\inetsrv\\appcmd.exe" add VDIR /app.name:"Default Web Site/" /path:"/test"' in directory 'C:\\Users\\svc_buildbambi'
    2015-03-02 10:46:13,475 [salt.loaded.int.module.cmdmod][ERROR   ] Command '"C:\\Windows\\System32\\inetsrv\\appcmd.exe" add VDIR /app.name:"Default Web Site/" /path:"/test"' failed with return code: 183
    2015-03-02 10:46:13,475 [salt.loaded.int.module.cmdmod][ERROR   ] stdout: ERROR ( message:Failed to add duplicate collection element "/test". )
    2015-03-02 10:46:13,475 [salt.loaded.int.module.cmdmod][ERROR   ] retcode: 183
    2015-03-02 10:46:13,475 [salt.loaded.ext.module.iis][ERROR   ] failed creating VDIR
    2015-03-02 10:46:13,475 [salt.loaded.ext.module.iis][DEBUG   ] 
    2015-03-02 10:46:13,475 [salt.state       ][ERROR   ] could not create vdir "Default Web Site/"
    2015-03-02 10:46:13,475 [salt.state       ][INFO    ] Completed state [/test] at time 10:46:13.475000
