### PR TITLE
wrong list that errors if Roles is set

### DIFF
--- a/grains/ec2_tags.py
+++ b/grains/ec2_tags.py
@@ -120,7 +120,7 @@ def ec2_tags():
 
     # Provide ec2_tags_roles functionality
     if 'Roles' in ec2_tags:
-        ret['ec2_roles'] = tags['Roles'].split(',')
+        ret['ec2_roles'] = ec2_tags['Roles'].split(',')
 
     return ret
 


### PR DESCRIPTION
If Roles is set in a ec2 tag this errored with the following

```
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/salt/loader.py", line 1251, in gen_grains
    ret = fun()
  File "/var/cache/salt/minion/extmods/grains/ec2_tags.py", line 123, in ec2_tags
    ret['ec2_roles'] = tags['Roles'].split(',')
```

It was just referencing the wrong list after the if statement. 