### PR TITLE
Adding a simple grain to emulate hostname -s in python.

### DIFF
--- a/grains/shortname.py
+++ b/grains/shortname.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: Nick Soracco
+    :copyright: © 2015 by Nick Soracco
+    :license: BSD
+
+    salt.grains.shortname
+    ~~~~~~~~~~~~~~~~~~~~~~~
+
+    Returns a string of the shortname of the machine, courtesy of
+	os.uname()[1].split('.')[0]
+
+    FIXME: Only works in Linux, requires uname() system call.
+'''
+
+import os
+
+def shortname():
+	'''
+	Return the first characters of a nodename prior to the first period.
+	'''
+	return { 'shortname': os.uname()[1].split('.')[0] }


### PR DESCRIPTION
Today, I ran into the `host:` grain returning a shortname, but one that I wasn't expecting.

The system in question has an IP address that is  not RFC1918, and I don't control either forward or reverse DNS for it.  So it returns some value from the ISP that's totally not what I want.

This grain does, regardless of the IP address of the system, via the `uname()` system call.