### PR TITLE
Record the ec2 instance-id as a top-level grain

### DIFF
--- a/grains/ec2_info.py
+++ b/grains/ec2_info.py
@@ -139,5 +139,33 @@ def ec2_info():
         LOG.info("Could not read EC2 data (IOError): %s" % (serr))
         return {}
 
+
+def ec2_instance_id():
+    """
+    Set the top-level grain 'instance-id' per the grain expected
+    by pillar-ec2.
+    """
+    try:
+        instance_id = _get_ec2_hostinfo("instance-id/").values()[0]
+        return {'instance-id' : instance_id}
+
+    except httplib.BadStatusLine, error:
+        LOG.debug(error)
+        return {}
+
+    except socket.timeout, serr:
+        LOG.info("Could not read EC2 data (timeout): %s" % (serr))
+        return {}
+
+    except socket.error, serr:
+        LOG.info("Could not read EC2 data (error): %s" % (serr))
+        return {}
+
+    except IOError, serr:
+        LOG.info("Could not read EC2 data (IOError): %s" % (serr))
+        return {}
+
+
 if __name__ == "__main__":
     print ec2_info()
+    print ec2_instance_id()


### PR DESCRIPTION
When using the ec2_pillar, the grain that it looks for
to identify the instance-id of an aws node is grains['instance-id'].
The ec2_info grain doesn't provide this, and as far
as I can tell, neither does anything else in the salt
ecosystem at this point.

In order to provide that, this commit adds another public function to
the ec2_info code that provides the 'instance-id' gtrain that the
ec2_pillar expects when it's configured with 'use_grain=True'.

The code in ec2_pillar that this supports is at:

https://github.com/saltstack/salt/blob/561d7b72bb8bb0d5fa5c4395db12425f27c26c1a/salt/pillar/ec2_pillar.py#L73-L91