### PR TITLE
#123: Fixed the ec2:public_key grain.  

### DIFF
--- a/grains/ec2_info.py
+++ b/grains/ec2_info.py
@@ -38,6 +38,8 @@ def _get_ec2_hostinfo(path=""):
     resp_data = resp.read().strip()
     d = {}
     for line in resp_data.split("\n"):
+        if path == "public-keys/":
+            line = line.split("=")[0] + "/"
         if line[-1] != "/":
             call_response = _call_aws("/latest/meta-data/%s" % (path + line))
             call_response_data = call_response.read()


### PR DESCRIPTION
Public keys are little different than other metadata - here's the AWS documentation on how to retrieve the public keys - http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html



This example gets the list of available public keys.

```bash
$ curl http://169.254.169.254/latest/meta-data/public-keys/

0=my-public-key
```

This example shows the formats in which public key 0 is available.

```bash
$ curl http://169.254.169.254/latest/meta-data/public-keys/0

openssh-key
```
This example gets public key 0 (in the OpenSSH key format).

```bash
$ curl http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key

ssh-rsa MIICiTCCAfICCQD6m7oRw0uXOjANBgkqhkiG9w0BAQUFADCBiDELMAkGA1UEBhMC
VVMxCzAJBgNVBAgTAldBMRAwDgYDVQQHEwdTZWF0dGxlMQ8wDQYDVQQKEwZBbWF6
b24xFDASBgNVBAsTC0lBTSBDb25zb2xlMRIwEAYDVQQDEwlUZXN0Q2lsYWMxHzAd
BgkqhkiG9w0BCQEWEG5vb25lQGFtYXpvbi5jb20wHhcNMTEwNDI1MjA0NTIxWhcN
MTIwNDI0MjA0NTIxWjCBiDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAldBMRAwDgYD
VQQHEwdTZWF0dGxlMQ8wDQYDVQQKEwZBbWF6b24xFDASBgNVBAsTC0lBTSBDb25z
b2xlMRIwEAYDVQQDEwlUZXN0Q2lsYWMxHzAdBgkqhkiG9w0BCQEWEG5vb25lQGFt
YXpvbi5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMaK0dn+a4GmWIWJ
21uUSfwfEvySWtC2XADZ4nB+BLYgVIk60CpiwsZ3G93vUEIO3IyNoH/f0wYK8m9T
rDHudUZg3qX4waLG5M43q7Wgc/MbQITxOUSQv7c7ugFFDzQGBzZswY6786m86gpE
Ibb3OhjZnzcvQAaRHhdlQWIMm2nrAgMBAAEwDQYJKoZIhvcNAQEFBQADgYEAtCu4
nUhVVxYUntneD9+h8Mg9q6q+auNKyExzyLwaxlAoo7TJHidbtS4J5iNmZgXL0Fkb
FFBjvSfpJIlJ00zbhNYS5f6GuoEDmFJl0ZxBHjJnyp378OD8uTs7fLvjx79LjSTb
NYiytVbZPQUQ5Yaxu2jXnimvw3rrszlaEXAMPLE my-public-key
```