### PR TITLE
jproperties renderer

### DIFF
--- a/renderers/jproperties.py
+++ b/renderers/jproperties.py
@@ -34,11 +34,12 @@ def render(jp_data, saltenv='base', sls='', **kws):
     if not isinstance(jp_data, string_types):
         jp_data = jp_data.read()
 
+    container = False
     if jp_data.startswith('#!'):
-        container = jp_data[:jp_data.find('\n')].split()[1]
+        args = jp_data[:jp_data.find('\n')].split()
+        if len(args) >= 2:
+            container = args[1]
         jp_data = jp_data[(jp_data.find('\n') + 1):]
-    else:
-        container = False
     if not jp_data.strip():
         return {}
     properties = jp()

--- a/renderers/jproperties.py
+++ b/renderers/jproperties.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+'''
+Java Property file Renderer for Salt
+http://aphor.github.io/jproperties_salt_renderer/
+'''
+
+from __future__ import absolute_import
+
+# Import 3rd party libs
+try:
+    from jproperties import Properties as jp
+    HAS_LIBS = True
+except ImportError:
+    HAS_LIBS = False
+
+# Import salt libs
+from salt.ext.six import string_types
+
+
+def render(jp_data, saltenv='base', sls='', **kws):
+    '''
+    Accepts Java Properties as a string or as a file object and runs it through the jproperties
+    parser.
+
+    :rtype: A Python data structure
+    '''
+    if not isinstance(jp_data, string_types):
+        jp_data = jp_data.read()
+
+    if jp_data.startswith('#!'):
+        container = jp_data[:jp_data.find('\n')].split()[1]
+        jp_data = jp_data[(jp_data.find('\n') + 1):]
+    else:
+        container = False
+    if not jp_data.strip():
+        return {}
+    properties = jp()
+    properties.load(jp_data)
+    if container:
+      return {container: dict([(k,properties[k]) for k in properties.iterkeys()])}
+    else:
+      return dict([(k,properties[k]) for k in properties.iterkeys()])

--- a/renderers/jproperties.py
+++ b/renderers/jproperties.py
@@ -20,7 +20,14 @@ from salt.ext.six import string_types
 def render(jp_data, saltenv='base', sls='', **kws):
     '''
     Accepts Java Properties as a string or as a file object and runs it through the jproperties
-    parser.
+    parser. Uses the jproperties package https://pypi.python.org/pypi/jproperties so please
+    "pip install jproperties" to use this renderer.
+    
+    Returns a flat dictionary by default:
+      {'some.java.thing': 'whatever'}
+    If using a 'shebang' "#!jproperties" header on the first line, an argument can be optionally
+    supplied as a key to contain a dictionary of the rendered properties (ie. "#!jproperties foo"):
+      {'foo': {'some.java.thing': 'whatever'}}
 
     :rtype: A Python data structure
     '''


### PR DESCRIPTION
Sometimes pillar or grains data might need to come from Java properties. This simple wrapper adds rendering using the jproperties package from PyPI.