### PR TITLE
Error handling - Some PHP version have broken document type header

### DIFF
--- a/modules/flup_fcgi_client.py
+++ b/modules/flup_fcgi_client.py
@@ -371,7 +371,9 @@ class FCGIApp(object):
             if not line:
                 break
 
-            # TODO: Better error handling
+            # Some PHP version have broken document type header
+            if ":" not in line:
+                continue
             header, value = line.split(':', 1)
             header = header.strip().lower()
             value = value.strip()


### PR DESCRIPTION
PHP 5.3.3 returns a broken header, e.g. 
----
X-Powered-By: PHP/5.3.3
application/jsonrequest
Content-type: text/html

{"accepted conn":6660,"pool":"cloudcell","process manager":"dynamic","idle processes":56,"active processes":1,"total processes":57}
--
It now ignores it and carry on with the execution.
