### PR TITLE
iis.py tries to load on linux with errors

### DIFF
--- a/states/iis.py
+++ b/states/iis.py
@@ -13,6 +13,9 @@ Note:
 import logging
 import re
 
+# Import salt libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 
@@ -20,7 +23,8 @@ def __virtual__():
     '''
     Load only on minions with the iis module
     '''
-    if 'iis.cert_list_permission' in __salt__:
+    if salt.utils.is_windows():
+    #if 'iis.cert_list_permission' in __salt__:
         return 'iis'
     return False
 


### PR DESCRIPTION
from [#virtual-function](https://docs.saltstack.com/en/latest/ref/modules/#virtual-function):

> Since \__virtual__ is called before the module is loaded, 
> \__salt__ will be unavailable as it will not have been packed into the module at this point in time.

On linux this state gets loaded, with an error because of the above reason. I understand that you want to only load the state module if the pillar module is also loaded, but the current method only works by coincidence.  The IIS pillar module uses salt.utils.is_windows(), so I thought that would be the best way to do this.

I realize it is a small change, and it does not check to see if the IIS pillar is loaded anymore but it came to my attention since we have linux and windows machines.