### PR TITLE
convert response data containing newlines to lists

### DIFF
--- a/grains/ec2_info.py
+++ b/grains/ec2_info.py
@@ -54,7 +54,12 @@ def _get_ec2_hostinfo(path=""):
                         data = _snake_caseify_dict(data)
                     d[line] = data
                 except ValueError:
-                    d[line] = call_response_data
+                    if "\n" in call_response_data:
+                        d[line] = []
+                        for dline in call_response_data.split("\n"):
+                            d[line].append(dline)
+                    else:
+                        d[line] = call_response_data
             else:
                 return line
         else:


### PR DESCRIPTION
This makes values returned for local_ipv4s with secondary IPs easier to work with.

`salt '*' grains.items --output=yaml`
before:
```
...
            local_ipv4s: '10.0.0.117

              10.0.0.114

              10.0.0.115

              10.0.0.116

              10.0.0.118

              10.0.0.119

              10.0.0.120

              10.0.0.121

              10.0.0.122

              10.0.0.123'

...
```

after:
```
...
            local_ipv4s:
            - 10.0.0.117
            - 10.0.0.114
            - 10.0.0.115
            - 10.0.0.116
            - 10.0.0.118
            - 10.0.0.119
            - 10.0.0.120
            - 10.0.0.121
            - 10.0.0.122
            - 10.0.0.123
...
```