### PR TITLE
Add OctopusDeploy client modules for Windows

### DIFF
--- a/modules/octopus_tentacle.py
+++ b/modules/octopus_tentacle.py
@@ -1,0 +1,668 @@
+# -*- coding: utf-8 -*-
+'''
+Module for managing Octopus Deploy Tentacle service settings on Windows servers.
+
+:platform:      Windows
+
+'''
+
+# Import python libs
+from __future__ import absolute_import
+from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
+import ast
+import json
+import logging
+import os
+import platform
+import re
+
+# Import salt libs
+from salt.exceptions import SaltException, SaltInvocationError
+from salt._compat import ElementTree
+import salt.utils
+
+_COMMS_STYLES = {'TentacleActive': True, 'TentaclePassive': False}
+_DEFAULT_COMMS = 'TentaclePassive'
+_DEFAULT_INSTANCE = 'Tentacle'
+_HKEY = 'HKLM'
+_LOG = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'octopus_tentacle'
+
+
+def __virtual__():
+    '''
+    Only works on Windows systems.
+    '''
+    if salt.utils.is_windows():
+        return __virtualname__
+    return False
+
+
+def _get_exe_path():
+    '''
+    Determine the Tentacle executable path.
+    '''
+    return os.path.join(_get_install_path(), 'Tentacle.exe')
+
+
+def _get_install_path():
+    '''
+    Determine the installation path from the relevant registry value.
+    '''
+    base_key = r'SOFTWARE\Octopus\Tentacle'
+    vname = 'InstallLocation'
+
+    value = (__salt__['reg.read_value'](_HKEY, base_key, vname))
+    if value.get('vdata', None):
+        return value['vdata']
+
+    message = r"Value data for '{0}' not found in {1}\{2}.".format(vname, _HKEY, base_key)
+    raise SaltException(message)
+
+
+def _get_version():
+    '''
+    Determine the version of the Tentacle executable.
+    '''
+    cmd = [_get_exe_path(), 'help', '--console']
+    cmd_ret = __salt__['cmd.run_all'](cmd)
+
+    if cmd_ret['retcode'] != 0:
+        _LOG.error('Unable to execute command: %s\nError: %s', cmd, cmd_ret['stderr'])
+        return None
+
+    help_text = [x.rstrip() for x in cmd_ret['stdout'].splitlines() if x.strip()]
+    match = re.search(r'version\s+(?P<version>[\d\.]+)\b', help_text[0])
+
+    if match:
+        _LOG.debug('Version found: %s', match.group('version'))
+        return match.group('version')
+    _LOG.error('Unable to parse line: %s', help_text[0])
+    return None
+
+
+def _parse_config(tree):
+    '''
+    Parse the ElementTree object. Tentacle config elements are formatted as follows:
+
+    .. code-block:: xml
+
+        <set key="KeyName">Value</set>
+    '''
+    ret = dict()
+    booleans = (False, True)
+
+    for child in tree:
+        if 'key' in child.attrib:
+            try:
+                # Some values are Json data.
+                value = json.loads(child.text)
+            except ValueError:
+                # If the value can be an integer or boolean, then make it so.
+                try:
+                    value = int(child.text)
+                except ValueError:
+                    text_capitalized = child.text.capitalize()
+                    if text_capitalized in booleans:
+                        try:
+                            value = ast.literal_eval(text_capitalized)
+                        except AttributeError:
+                            pass
+                    else:
+                        value = child.text
+            ret[child.attrib['key']] = value
+
+    return ret
+
+
+def _validate_comms(comms):
+    '''
+    Validate the communications style provided.
+    '''
+    if comms not in get_comms_styles():
+        message = ("Invalid communications style '{0}' specified. Valid comms:"
+                   ' {1}').format(comms, get_comms_styles())
+        raise SaltInvocationError(message)
+
+
+def version_is_3_or_newer():
+    '''
+    Determine if the Tentacle executable version is 3.0 or newer.
+
+    :return: A boolean indicating if the executable version is 3.0 or newer.
+    :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' octopus_tentacle.version_is_3_or_newer
+    '''
+    version = str(_get_version())
+    if LooseVersion(version) >= LooseVersion('3.0'):
+        return True
+    return False
+
+
+def get_comms_styles():
+    '''
+    Determine the available communication styles.
+
+    :return: A list of the communication styles.
+    :rtype: list
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' octopus_tentacle.get_comms_styles
+    '''
+    return _COMMS_STYLES.keys()
+
+
+def get_config_path(instance=_DEFAULT_INSTANCE):
+    '''
+    Determine the configuration file used for the provided instance.
+
+    :param str instance: The name of the Tentacle instance.
+
+    :return: A string containing the configuration file path.
+    :rtype: str
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' octopus_tentacle.get_config_path instance='Tentacle'
+    '''
+    ret = str()
+    instance_key = r'SOFTWARE\Octopus\Tentacle\{0}'.format(instance)
+
+    value = (__salt__['reg.read_value'](_HKEY, instance_key, 'ConfigurationFilePath'))
+
+    if value.get('vdata', None):
+        ret = value['vdata']
+    else:
+        _LOG.warn('Unable to get configuration path for instance: %s', instance)
+
+    return ret
+
+
+def set_config_path(path=r'C:\Octopus\Tentacle\Tentacle.config', instance=_DEFAULT_INSTANCE):
+    '''
+    Manage the configuration file for the provided instance.
+
+    :param str path: The path to the configuration file.
+    :param str instance: The name of the Tentacle instance.
+
+    :return: A boolean representing whether the change succeeded.
+    :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' octopus_tentacle.set_config path='C:\\Octopus\\Tentacle.config' instance='Tentacle'
+    '''
+    current_path = get_config_path(instance)
+
+    if (path == current_path) and os.path.isfile(path):
+        _LOG.debug("Config file already present: %s", path)
+        return True
+
+    cmd = [_get_exe_path(), 'create-instance', '--instance', instance, '--config', path]
+    cmd.append('--console')
+
+    cmd_ret = __salt__['cmd.run_all'](cmd)
+
+    if cmd_ret['retcode'] == 0:
+        _LOG.debug('Config file created successfully: %s', path)
+        return True
+    _LOG.error('Unable to execute command: %s\nError: %s', cmd, cmd_ret['stderr'])
+    return False
+
+
+def get_config(instance=_DEFAULT_INSTANCE):
+    '''
+    Determine the configuration of the provided instance.
+
+    :param str instance: The name of the Tentacle instance.
+
+    :return: A dictionary containing the configuration data.
+    :rtype: dict
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' octopus_tentacle.get_config instance='Tentacle'
+    '''
+    ret = dict()
+    name_mapping = {'Octopus.Home': 'home_path',
+                    'Octopus.Communications.Squid': 'squid',
+                    'Tentacle.CertificateThumbprint': 'thumbprint',
+                    'Tentacle.Communication.TrustedOctopusServers': 'servers',
+                    'Tentacle.Deployment.ApplicationDirectory': 'app_path',
+                    'Tentacle.Services.NoListen': 'comms',
+                    'Tentacle.Services.PortNumber': 'port'}
+
+    config_path = get_config_path(instance)
+
+    if not os.path.isfile(config_path):
+        _LOG.error('Unable to get configuration file for instance: %s', instance)
+        return ret
+
+    with salt.utils.fopen(config_path, 'r') as fh_:
+        config = _parse_config(ElementTree.fromstring(fh_.read()))
+
+    for item in config:
+        # Skip keys that we aren't specifically looking for.
+        if item in name_mapping:
+            # Convert the NoListen value to a friendly value.
+            if name_mapping[item] == 'comms':
+                for comms_style in _COMMS_STYLES:
+                    if config[item] == _COMMS_STYLES[comms_style]:
+                        ret[name_mapping[item]] = comms_style
+                        break
+            else:
+                ret[name_mapping[item]] = config[item]
+
+    return ret
+
+
+def set_config(home_path=r'C:\Octopus', app_path=r'C:\Octopus\Applications', port=10933,
+               comms=_DEFAULT_COMMS, generate_cert=True, generate_squid=True,
+               instance=_DEFAULT_INSTANCE):
+    '''
+    Manage the application configuration of the provided instance.
+
+    :param str home_path: The path that will serve as the Tentacle home.
+    :param str app_path: The directory for the installation of application packages.
+    :param int port: The TCP port for the instance.
+    :param str comms: The communication style for the instance. Valid values can be found by
+    running octopus_tentacle.get_comms_styles.
+    :param bool generate_cert: Whether to generate a certificate.
+    :param bool generate_squid: Whether to generate a SQUID.
+    :param str instance: The name of the Tentacle instance.
+
+    :return: A boolean representing whether the change succeeded.
+    :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' octopus_tentacle.set_app home_path='C:\\Octopus' app_path='C:\\Apps' port=10933
+    '''
+    kwarg_names = ['home_path', 'app_path', 'port']
+    version = version_is_3_or_newer()
+
+    # The noListen parameter is only used with version 3.0 or newer.
+    if version:
+        kwarg_names.append('comms')
+
+    config = dict([(name, locals()[name]) for name in kwarg_names])
+
+    _validate_comms(comms)
+
+    current_config_full = get_config(instance)
+    current_config = dict()
+
+    if current_config_full:
+        current_config = dict([(name, current_config_full[name]) for name in kwarg_names])
+    else:
+        if not get_config_path():
+            _LOG.error('Unable to get configuration path for instance: %s', instance)
+            return False
+
+    # If required, generate a certificate if one is not already present.
+    if generate_cert:
+        if not set_cert(instance=instance):
+            _LOG.error('Unable to generate certificate successfully for instance: %s', instance)
+            return False
+
+    # If required, generate a SQUID if one is not already present.
+    if generate_squid:
+        if not set_squid(instance=instance):
+            _LOG.error('Unable to generate SQUID successfully for instance: %s', instance)
+            return False
+
+    if config == current_config:
+        _LOG.debug('Config already contains the provided values.')
+        return True
+
+    cmd = [_get_exe_path(), 'configure', '--instance', instance, '--home', home_path]
+    cmd.extend(['--app', app_path, '--port', port])
+
+    if version:
+        cmd.extend(['--noListen', str(_COMMS_STYLES[comms])])
+
+    cmd.append('--console')
+    cmd_ret = __salt__['cmd.run_all'](cmd)
+
+    if cmd_ret['retcode'] == 0:
+        _LOG.debug('Configured instance successfully: %s', instance)
+        return True
+    _LOG.error('Unable to execute command: %s\nError: %s', cmd, cmd_ret['stderr'])
+    return False
+
+
+def set_cert(force=False, instance=_DEFAULT_INSTANCE):
+    '''
+    Generate a tentacle certificate for the provided instance.
+
+    :param bool force: Whether to generate a certificate even if one already exists.
+    :param str instance: The name of the Tentacle instance.
+
+    :return: A boolean representing whether the change succeeded.
+    :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' octopus_tentacle.set_cert force='False' instance='Tentacle'
+    '''
+    current_config = get_config(instance)
+
+    if 'thumbprint' in current_config and not force:
+        _LOG.debug('Certificate already exists for instance: %s', instance)
+        return True
+
+    cmd = [_get_exe_path(), 'new-certificate', '--instance', instance]
+
+    if 'thumbprint' not in current_config or not force:
+        cmd.append('--if-blank')
+    cmd.append('--console')
+
+    cmd_ret = __salt__['cmd.run_all'](cmd)
+
+    if cmd_ret['retcode'] == 0:
+        _LOG.debug('Configured certificate successfully for instance: %s', instance)
+        return True
+    _LOG.error('Unable to execute command: %s\nError: %s', cmd, cmd_ret['stderr'])
+    return False
+
+
+def set_squid(instance=_DEFAULT_INSTANCE):
+    '''
+    Manage the SQUID of the provided instance.
+
+    :return: A boolean representing whether the change succeeded.
+    :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' octopus_tentacle.set_squid instance='Tentacle'
+    '''
+    if version_is_3_or_newer():
+        _LOG.debug('SQUID not required for version 3.0 or later.')
+        return True
+
+    current_config = get_config(instance)
+
+    if 'squid' in current_config and current_config['squid']:
+        _LOG.debug('Config already contains SQUID: %s', current_config['squid'])
+        return True
+
+    cmd = [_get_exe_path(), 'new-squid', '--instance', instance, '--console']
+    cmd_ret = __salt__['cmd.run_all'](cmd)
+
+    if cmd_ret['retcode'] == 0:
+        _LOG.debug('Configured SQUID successfully for instance: %s', instance)
+        return True
+    _LOG.error('Unable to execute command: %s\nError: %s', cmd, cmd_ret['stderr'])
+    return False
+
+
+def set_trust(thumbprint, reset=False, instance=_DEFAULT_INSTANCE):
+    '''
+    Manage the server thumbprint trust of the provided instance.
+
+    :param str thumbprint: The thumbprint of the Octopus Deploy server.
+    :param bool reset: Whether to reset the trust relationship if the thumbprint is not already trusted.
+    :param str instance: The name of the Tentacle instance.
+
+    :return: A boolean representing whether the change succeeded.
+    :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' octopus_tentacle.set_trust thumbprint='AAA000' reset='False' instance='Tentacle'
+    '''
+    current_config = get_config(instance)
+
+    if 'servers' in current_config and current_config['servers']:
+        for server in current_config['servers']:
+            if thumbprint == server['Thumbprint']:
+                _LOG.debug('Config already contains server thumbprint: %s', thumbprint)
+                return True
+    else:
+        # If there are no current trusts, then we should flag to run reset-trust anyway.
+        reset = True
+
+    cmd_ret = dict()
+
+    # If reset has been passed in or if this is the first trust defined
+    # for this instance then reset-trust should be performed.
+    if reset:
+        cmd = [_get_exe_path(), 'configure', '--instance', instance, '--reset-trust', '--console']
+        cmd_ret = __salt__['cmd.run_all'](cmd)
+
+        if cmd_ret['retcode'] != 0:
+            _LOG.error('Unable to execute command: %s\nError: %s', cmd, cmd_ret['stderr'])
+            return False
+
+    cmd = [_get_exe_path(), 'configure', '--instance', instance, '--trust', thumbprint, '--console']
+
+    cmd_ret = __salt__['cmd.run_all'](cmd)
+
+    if cmd_ret['retcode'] == 0:
+        _LOG.debug('Config changed to include server thumbprint: %s', thumbprint)
+        return True
+    _LOG.error('Unable to execute command: %s\nError: %s', cmd, cmd_ret['stderr'])
+    return False
+
+
+def get_registration(server, api_key):
+    '''
+    Determine the registration of the machine.
+
+    :param str server: The URI of the Octopus Deploy server.
+    :param str api_key: The API key for registration of the Tentacle.
+
+    :return: A dictionary containing the configuration data.
+    :rtype: dict
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' octopus_tentacle.get_registration server='http://srvr' api_key='API-000'
+    '''
+    ret = dict()
+    # We use the client DLL here instead of a salt.utils.http query because
+    # we don't have a way of getting the unique machine ID, and /machines/all
+    # would require checking potentially hundreds of entries.
+    dll_path = os.path.join(_get_install_path(), 'Octopus.Client.dll')
+
+    # Expressions will always collapse 0-1 length arrays, so we need to assign the
+    # environments after the Select-Object has been performed so that the value is
+    # a consistent type.
+    cmd = ["Add-Type -Path '{0}'; $Endpoint =".format(dll_path)]
+    cmd.append(" New-Object Octopus.Client.OctopusServerEndpoint '{0}', '{1}';".format(server, api_key))
+    cmd.append(' $Repo = New-Object Octopus.Client.OctopusRepository $Endpoint;')
+    cmd.append(' $Envs = @($Repo.Environments.FindAll() | Select-Object Id, Name)')
+    cmd.append(r' | Foreach { @{ $_.Id = $_.Name } };')
+    cmd.append(' $Machine = $Repo.Machines.FindByName($Env:ComputerName) | Select-Object')
+    cmd.append(r" Roles, EnvironmentIds, @{ Name='Environments'; Expression={ @() } },")
+    cmd.append(r" @{ Name='CommunicationStyle'; Expression={ ")
+    cmd.append(' $_.EndPoint.CommunicationStyle.ToString() }};')
+    cmd.append(r' if ($Machine) { $Machine.Environments = @($Machine.EnvironmentIds')
+    cmd.append(r' | Foreach { $Envs[$_] }) };')
+    cmd.append(" ConvertTo-Json -Compress -Depth 4 -InputObject @($Machine)")
+
+    cmd_ret = __salt__['cmd.run_all'](str().join(cmd), shell='powershell', python_shell=True)
+
+    if cmd_ret['retcode'] != 0:
+        _LOG.error('Unable to execute command: %s\nError: %s', cmd, cmd_ret['stderr'])
+        return ret
+
+    try:
+        items = json.loads(cmd_ret['stdout'], strict=False)
+    except ValueError:
+        _LOG.error('Unable to parse return data as Json.')
+
+    # FindByName returns $Null if the name is not found.
+    if len(items) == 1 and not items[0]:
+        _LOG.debug("Machine registration not found.")
+        return ret
+
+    for item in items:
+        ret = {
+            'envs': list(),
+            'roles': list(),
+        }
+
+        ret['envs'].extend(item['Environments'])
+        ret['roles'].extend(item['Roles'])
+
+    if not ret:
+        _LOG.warning('No valid data found in output: %s', cmd_ret['stdout'])
+
+    if 'envs' in ret:
+        ret['envs'] = sorted(ret['envs'])
+    if 'roles' in ret:
+        ret['roles'] = sorted(ret['roles'])
+
+    return ret
+
+def set_registration(server, envs, roles, api_key, user=None, password=None, port=10943,
+                     comms=_DEFAULT_COMMS, instance=_DEFAULT_INSTANCE):
+    '''
+    Manage the registration of the Tentacle with the Octopus Deploy server.
+
+    :param str server: The URI of the Octopus Deploy server.
+    :param str envs: The environments for the Tentacle.
+    :param str roles: The roles defined for the Tentacle.
+    :param str api_key: The API key for registration of the Tentacle.
+    :param str user: The server username.
+    :param str password: The server password.
+    :param int port: The TCP communications port for the server.
+    :param str comms: The communication style for the instance. Valid values can be found by
+    running octopus_tentacle.get_comms_styles.
+    :param str instance: The name of the Tentacle instance.
+
+    .. note:
+
+        The api_key parameter is required for the purpose of determining the current
+        registration status, even when the user and password parameters are configured.
+
+    :return: A boolean representing whether the change succeeded.
+    :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' octopus_tentacle.registration server='http://srvr' envs="['Dev']" roles="['Web']" api_key='API-000'
+    '''
+    kwarg_names = ('envs', 'roles')
+    registration = dict([(name, sorted(locals()[name])) for name in kwarg_names])
+
+    current_registration = get_registration(server, api_key)
+
+    if registration == current_registration:
+        _LOG.debug('Registration already present for server: %s', server)
+        return True
+
+    _validate_comms(comms)
+    exe_path = _get_exe_path()
+
+    cmd = [exe_path, 'register-with', '--instance', instance, '--server', server]
+    cmd.extend(['--comms-style', comms])
+
+    if comms == 'TentaclePassive':
+        cmd.extend(['--apiKey', api_key])
+    else:
+        if not user:
+            raise SaltInvocationError('Value of user must be specified for comms: {0}'.format(comms))
+        cmd.extend(['--name', platform.node()])
+        cmd.extend(['--username', user, '--password', password, '--server-comms-port', port])
+
+    for role in roles:
+        cmd.extend(['--role', role])
+    for env in envs:
+        cmd.extend(['--environment', env])
+
+    cmd.extend(['--force', '--console'])
+
+    cmd_ret = __salt__['cmd.run_all'](cmd)
+
+    if cmd_ret['retcode'] != 0:
+        _LOG.error('Unable to execute command: %s\nError: %s', cmd, cmd_ret['stderr'])
+        return False
+
+    cmd = [exe_path, 'service', '--instance', instance, '--install', '--start']
+
+    cmd_ret = __salt__['cmd.run_all'](cmd)
+
+    if cmd_ret['retcode'] == 0:
+        _LOG.debug('Registration successful for server: %s', server)
+        return True
+    _LOG.error('Unable to execute command: %s\nError: %s', cmd, cmd_ret['stderr'])
+    return False
+
+def set_deregistration(server, api_key, user=None, password=None, instance=_DEFAULT_INSTANCE):
+    '''
+    Revoke registration of the Tentacle with the Octopus Deploy server.
+
+    :param str server: The URI of the Octopus Deploy server.
+    :param str api_key: The API key for registration of the Tentacle.
+    :param str user: The server username.
+    :param str password: The server password.
+    :param str instance: The name of the Tentacle instance.
+
+    .. note:
+
+        The api_key parameter is required for the purpose of determining the current
+        registration status, even when the user and password parameters are configured.
+
+    :return: A boolean representing whether the change succeeded.
+    :rtype: bool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+    salt '*' octopus_tentacle.set_deregistration server='http://srvr' api-key='API-000' instance='default'
+
+    '''
+    current_registration = get_registration(server, api_key)
+
+    if 'envs' not in current_registration or not current_registration['envs']:
+        _LOG.debug('Registration already revoked for server: %s', server)
+        return True
+
+    cmd = [_get_exe_path(), 'deregister-from', '--instance', instance, '--server', server]
+
+    if user:
+        cmd.extend(['--username', user, '--password', password])
+    else:
+        cmd.extend(['--apiKey', api_key])
+
+    cmd.append('--console')
+
+    cmd_ret = __salt__['cmd.run_all'](cmd)
+
+    if cmd_ret['retcode'] == 0:
+        _LOG.debug('Registration revoked for server: %s', server)
+        return True
+    _LOG.error('Unable to execute command: %s\nError: %s', cmd, cmd_ret['stderr'])
+    return False

--- a/states/octopus_tentacle.py
+++ b/states/octopus_tentacle.py
@@ -1,0 +1,325 @@
+# -*- coding: utf-8 -*-
+'''
+Module for managing Octopus Deploy Tentacle service settings on Windows servers.
+
+:platform:      Windows
+
+'''
+
+# Import python libs
+from __future__ import absolute_import
+
+_DEFAULT_COMMS = 'TentaclePassive'
+_DEFAULT_INSTANCE = 'Tentacle'
+
+# Define the module's virtual name
+__virtualname__ = 'octopus_tentacle'
+
+
+def __virtual__():
+    '''
+    Load only on minions that have the octopus_tentacle module.
+    '''
+    if 'octopus_tentacle.get_config' in __salt__:
+        return __virtualname__
+    return False
+
+
+def config_path(name, path=r'C:\Octopus\Tentacle\Tentacle.config', instance=_DEFAULT_INSTANCE):
+    '''
+    Manage the configuration file for the provided instance.
+
+    :param str path: The path to the configuration file.
+    :param str instance: The name of the Tentacle instance.
+
+    Example of usage:
+
+    .. code-block:: yaml
+
+        tentacle-config-path:
+            octopus_tentacle.config_path:
+                - path: C:\\Octopus\\Tentacle\\Tentacle.config
+
+    '''
+    ret = {'name': name,
+           'changes': dict(),
+           'comment': str(),
+           'result': None}
+    current_path = __salt__['octopus_tentacle.get_config_path'](instance)
+
+    if path == current_path:
+        ret['comment'] = 'Config file already present: {0}'.format(path)
+        ret['result'] = True
+    elif __opts__['test']:
+        ret['comment'] = 'Config file will be created: {0}'.format(path)
+        ret['changes'] = {'old': current_path,
+                          'new': path}
+    else:
+        ret['changes'] = {'old': current_path,
+                          'new': path}
+        ret['result'] = __salt__['octopus_tentacle.set_config_path'](path, instance)
+
+        if ret['result']:
+            ret['comment'] = 'Config file created successfully: {0}'.format(path)
+        else:
+            ret['comment'] = 'Config file failed to be created: {0}'.format(path)
+    return ret
+
+
+def configured(name, home_path=r'C:\Octopus', app_path=r'C:\Octopus\Applications', port=10933,
+               comms=_DEFAULT_COMMS, generate_cert=True, generate_squid=True,
+               instance=_DEFAULT_INSTANCE):
+    '''
+    Manage the application configuration of the provided instance.
+
+    :param str home_path: The path that will serve as the Tentacle home.
+    :param str app_path: The directory for the installation of application packages.
+    :param int port: The TCP port for the instance.
+    :param str comms: The communication style for the instance. Valid values can be found by
+    running octopus_tentacle.get_comms_styles.
+    :param bool generate_cert: Whether to generate a certificate.
+    :param bool generate_squid: Whether to generate a SQUID.
+    :param str instance: The name of the Tentacle instance.
+
+    Example of usage:
+
+    .. code-block:: yaml
+
+        tentacle-configured:
+            octopus_tentacle.configured:
+                - home_path: C:\\Octopus
+                - app_path: C:\\Octopus\\Applications
+                - port: 10933
+                - comms: TentaclePassive
+                - generate_cert: True
+                - generate_squid: True
+    '''
+    ret = {'name': name,
+           'changes': dict(),
+           'comment': str(),
+           'result': None}
+
+    kwarg_names = ['home_path', 'app_path', 'port']
+
+    # The noListen parameter is only used with version 3.0 or newer.
+    if __salt__['octopus_tentacle.version_is_3_or_newer']():
+        kwarg_names.append('comms')
+
+    config = dict([(name, locals()[name]) for name in kwarg_names])
+
+    current_config_full = __salt__['octopus_tentacle.get_config'](instance)
+    current_config = dict()
+
+    if current_config_full:
+        current_config = dict([(name, current_config_full[name]) for name in kwarg_names])
+
+    if config == current_config:
+        ret['comment'] = 'Config already contains provided values.'
+        ret['result'] = True
+    elif __opts__['test']:
+        ret['comment'] = 'Config will be changed to include provided values.'
+        ret['changes'] = {'old': current_config,
+                          'new': config}
+    else:
+        ret['changes'] = {'old': current_config,
+                          'new': config}
+        ret['result'] = __salt__['octopus_tentacle.set_config'](home_path, app_path, port, comms,
+                                                                generate_cert, generate_squid,
+                                                                instance)
+        if ret['result']:
+            ret['comment'] = 'Config changed to include provided values.'
+        else:
+            ret['comment'] = 'Config failed to include provided values.'
+    return ret
+
+
+def trusted(name, thumbprint, reset=False, instance=_DEFAULT_INSTANCE):
+    '''
+    Manage the server thumbprint trust of the provided instance.
+
+    :param str thumbprint: The thumbprint of the Octopus Deploy server.
+    :param bool reset: Whether to reset the trust relationship if the thumbprint is not already trusted.
+    :param str instance: The name of the Tentacle instance.
+
+    Example of usage:
+
+    .. code-block:: yaml
+
+        tentacle-trusted:
+            octopus_tentacle.trusted:
+                - thumbprint: 9988776655443322111000AAABBBCCCDDDEEEFFF
+                - reset: False
+    '''
+    ret = {'name': name,
+           'changes': dict(),
+           'comment': str(),
+           'result': None}
+
+    thumbprint_present = False
+    current_config = __salt__['octopus_tentacle.get_config'](instance)
+
+    if 'servers' in current_config:
+        for server in current_config['servers']:
+            if thumbprint == server['Thumbprint']:
+                thumbprint_present = True
+
+    if thumbprint_present:
+        ret['comment'] = 'Config already contains server thumbprint: {0}'.format(thumbprint)
+        ret['result'] = True
+    elif __opts__['test']:
+        ret['comment'] = 'Config will be changed to include the server thumbprint: {0}'.format(thumbprint)
+        ret['changes'] = {'old': None,
+                          'new': thumbprint}
+    else:
+        ret['changes'] = {'old': None,
+                          'new': thumbprint}
+        ret['result'] = __salt__['octopus_tentacle.set_trust'](thumbprint, reset, instance)
+
+        if ret['result']:
+            ret['comment'] = 'Config changed to include server thumbprint: {0}'.format(thumbprint)
+        else:
+            ret['comment'] = 'Config failed to include server thumbprint: {0}'.format(thumbprint)
+    return ret
+
+def registered(name, server, envs, roles, api_key, user=None, password=None, port=10943,
+               comms=_DEFAULT_COMMS, instance=_DEFAULT_INSTANCE):
+    '''
+    Manage the registration of the Tentacle with the Octopus Deploy server.
+
+    :param str server: The URI of the Octopus Deploy server.
+    :param str envs: The environments for the Tentacle.
+    :param str roles: The roles defined for the Tentacle.
+    :param str api_key: The API key for registration of the Tentacle.
+    :param str user: The server username.
+    :param str password: The server password.
+    :param int port: The TCP communications port for the server.
+    :param str comms: The communication style for the instance. Valid values can be found by
+    running octopus_tentacle.get_comms_styles.
+    :param str instance: The name of the Tentacle instance.
+
+    .. note:
+
+        The api_key parameter is required for the purpose of determining the current
+        registration status, even when the user and password parameters are configured.
+
+    Example of usage with only the required arguments:
+
+    .. code-block:: yaml
+
+        tentacle-registered:
+            octopus_tentacle.registered:
+                - server: http://server:8080
+                - envs:
+                    - Dev
+                - roles:
+                    - Web
+                - api_key: API-AAAAABBBBBCCCCCDDDDDEEEEFFFF
+
+    Example of usage specifying the user and password parameters for a polling Tentacle:
+
+    .. code-block:: yaml
+
+        tentacle-registered:
+            octopus_tentacle.registered:
+                - server: http://server:8080
+                - envs:
+                    - Dev
+                - roles:
+                    - Web
+                - api_key: API-AAAAABBBBBCCCCCDDDDDEEEEFFFF
+                - user: TestUser
+                - password: TestPassword
+                - port: 10943
+                - comms: TentacleActive
+    '''
+    ret = {'name': name,
+           'changes': dict(),
+           'comment': str(),
+           'result': None}
+    kwarg_names = ('envs', 'roles')
+    registration = dict([(name, sorted(locals()[name])) for name in kwarg_names])
+
+    current_registration = __salt__['octopus_tentacle.get_registration'](server, api_key)
+
+    if registration == current_registration:
+        ret['comment'] = 'Registration already present for server: {0}'.format(server)
+        ret['result'] = True
+    elif __opts__['test']:
+        ret['comment'] = 'Registration will be created for server: {0}'.format(server)
+        ret['changes'] = {'old': None,
+                          'new': server}
+    else:
+        ret['changes'] = {'old': None,
+                          'new': server}
+        ret['result'] = __salt__['octopus_tentacle.set_registration'](server, envs, roles,
+                                                                      api_key, user, password,
+                                                                      port, comms, instance)
+        if ret['result']:
+            ret['comment'] = 'Registration successful for server: {0}'.format(server)
+        else:
+            ret['comment'] = 'Registration failed for server: {0}'.format(server)
+
+    return ret
+
+
+def deregistered(name, server, api_key, user=None, password=None, instance=_DEFAULT_INSTANCE):
+    '''
+    Revoke registration of the Tentacle with the Octopus Deploy server.
+
+    :param str server: The URI of the Octopus Deploy server.
+    :param str api_key: The API key for registration of the Tentacle.
+    :param str user: The server username.
+    :param str password: The server password.
+    :param str instance: The name of the Tentacle instance.
+
+    .. note:
+
+        The api_key parameter is required for the purpose of determining the current
+        registration status, even when the user and password parameters are configured.
+
+     Example of usage with only the required arguments:
+
+    .. code-block:: yaml
+
+        tentacle-deregistered:
+            octopus_tentacle.deregistered:
+                - server: http://server:8080
+                - api_key: API-AAAAABBBBBCCCCCDDDDDEEEEFFFF
+
+    Example of usage specifying the user and password parameters for a polling Tentacle:
+
+    .. code-block:: yaml
+
+        tentacle-deregistered:
+            octopus_tentacle.deregistered:
+                - server: http://server:8080
+                - api_key: API-AAAAABBBBBCCCCCDDDDDEEEEFFFF
+                - user: TestUser
+                - password: TestPassword
+    '''
+    ret = {'name': name,
+           'changes': dict(),
+           'comment': str(),
+           'result': None}
+
+    current_registration = __salt__['octopus_tentacle.get_registration'](server, api_key)
+
+    if 'envs' not in current_registration or not current_registration['envs']:
+        ret['comment'] = 'Registration already revoked for server: {0}'.format(server)
+        ret['result'] = True
+    elif __opts__['test']:
+        ret['comment'] = 'Registration will be revoked for server:{0}'.format(server)
+        ret['changes'] = {'old': server,
+                          'new': None}
+    else:
+        ret['changes'] = {'old': server,
+                          'new': None}
+        ret['result'] = __salt__['octopus_tentacle.set_registration'](server, api_key,
+                                                                      user, password,
+                                                                      instance)
+        if ret['result']:
+            ret['comment'] = 'Registration revoked for server: {0}'.format(server)
+        else:
+            ret['comment'] = 'Registration failed to revoke for server: {0}'.format(server)
+
+    return ret

--- a/tests/unit/modules/octopus_tentacle_test.py
+++ b/tests/unit/modules/octopus_tentacle_test.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+'''
+    :synopsis: Unit Tests for OctopusDeploy Tentacle Module 'modules.octopus_tentacle'
+    :platform: Windows
+    :maturity: develop
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Libs
+from salt.modules import octopus_tentacle
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import (
+    MagicMock,
+    mock_open,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON,
+)
+
+ensure_in_syspath('../../')
+
+# Globals
+octopus_tentacle.__salt__ = {}
+
+# Make sure this module runs on Windows system
+HAS_TENTACLE = octopus_tentacle.__virtual__()
+
+DEFAULT_CONFIG_PATH = r'C:\Octopus\Tentacle\Tentacle.config'
+EXE_PATH = r'C:\Program Files\Octopus Deploy\Tentacle\Tentacle.exe'
+
+CONFIG_DICT = {
+    'app_path': r'C:\Octopus\Applications',
+    'home_path': r'C:\Octopus',
+    'port': 10933,
+    'servers': [{
+        'Address': None,
+        'CommunicationStyle': 'TentaclePassive',
+        'Squid': 'SQ-TEST01-FFFF9999',
+        'Thumbprint': '9988776655443322111000AAABBBCCCDDDEEEFFF',
+    }],
+    'squid': 'SQ-TEST01-AAAA0000',
+    'thumbprint': '9988776655443322111000AAABBBCCCDDDEEEFFF',
+}
+FILE_CONTENT = r'''<?xml version="1.0" encoding="utf-8"?>
+<octopus-settings xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <set key="Octopus.Communications.Squid">SQ-TEST01-AAAA0000</set>
+  <set key="Octopus.Home">C:\Octopus</set>
+  <set key="Tentacle.CertificateThumbprint">9988776655443322111000AAABBBCCCDDDEEEFFF</set>
+  <set key="Tentacle.Communication.TrustedOctopusServers">[{"Thumbprint":"9988776655443322111000AAABBBCCCDDDEEEFFF","CommunicationStyle":"TentaclePassive","Address":null,"Squid":"SQ-TEST01-FFFF9999"}]</set>
+  <set key="Tentacle.Deployment.ApplicationDirectory">C:\Octopus\Applications</set>
+  <set key="Tentacle.Services.PortNumber">10933</set>
+</octopus-settings>'''
+
+
+@skipIf(not HAS_TENTACLE, 'This test case runs only on Windows systems')
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class OctopusTentacleTestCase(TestCase):
+    '''
+    Test cases for salt.modules.octopus_tentacle
+    '''
+
+    @patch('salt.modules.octopus_tentacle._get_version',
+           MagicMock(return_value='2.5.12.666'))
+    def test_version_is_3_or_newer(self):
+        '''
+        Test - Determine if the Tentacle executable version is 3.0 or newer.
+        '''
+        with patch.dict(octopus_tentacle.__salt__):
+            self.assertFalse(octopus_tentacle.version_is_3_or_newer())
+
+    def test_get_comms_styles(self):
+        '''
+        Test - Determine the available communication styles.
+        '''
+        comms_styles = set(['TentacleActive', 'TentaclePassive'])
+        with patch.dict(octopus_tentacle.__salt__):
+            self.assertEqual(set(octopus_tentacle.get_comms_styles()),
+                             comms_styles)
+
+    def test_get_config_path(self):
+        '''
+        Test - Determine the configuration file used for the provided instance.
+        '''
+        mock_value = MagicMock(return_value={'vdata': DEFAULT_CONFIG_PATH})
+        with patch.dict(octopus_tentacle.__salt__, {'reg.read_value': mock_value}):
+            self.assertEqual(octopus_tentacle.get_config_path(),
+                             DEFAULT_CONFIG_PATH)
+
+    @patch('salt.modules.octopus_tentacle._get_exe_path',
+           MagicMock(return_value=EXE_PATH))
+    @patch('salt.modules.octopus_tentacle.get_config_path',
+           MagicMock(return_value=DEFAULT_CONFIG_PATH))
+    @patch('os.path.isfile',
+           MagicMock(return_value=False))
+    def test_set_config_path(self):
+        '''
+        Test - Manage the configuration file for the provided instance.
+        '''
+        mock_cmd = MagicMock(return_value={'retcode': 0})
+        with patch.dict(octopus_tentacle.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertTrue(octopus_tentacle.set_config_path(r'C:\Test.config'))
+
+    @patch('salt.modules.octopus_tentacle.get_config_path',
+           MagicMock(return_value=DEFAULT_CONFIG_PATH))
+    @patch('os.path.isfile',
+           MagicMock(return_value=True))
+    @patch('salt.utils.fopen',
+           mock_open(read_data=FILE_CONTENT))
+    def test_get_config(self):
+        '''
+        Test - Determine the configuration of the provided instance.
+        '''
+        with patch.dict(octopus_tentacle.__salt__):
+            self.assertEqual(octopus_tentacle.get_config(),
+                             CONFIG_DICT)
+
+    @patch('salt.modules.octopus_tentacle._get_exe_path',
+           MagicMock(return_value=EXE_PATH))
+    @patch('salt.modules.octopus_tentacle.version_is_3_or_newer',
+           MagicMock(return_value=False))
+    @patch('salt.modules.octopus_tentacle.get_config',
+           MagicMock(return_value=CONFIG_DICT))
+    @patch('salt.modules.octopus_tentacle.get_config_path',
+           MagicMock(return_value=DEFAULT_CONFIG_PATH))
+    @patch('salt.modules.octopus_tentacle.set_cert',
+           MagicMock(return_value=True))
+    @patch('salt.modules.octopus_tentacle.set_squid',
+           MagicMock(return_value=True))
+    def test_set_config(self):
+        '''
+        Test - Manage the application configuration of the provided instance.
+        '''
+        mock_cmd = MagicMock(return_value={'retcode': 0})
+        with patch.dict(octopus_tentacle.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertTrue(octopus_tentacle.set_config())
+
+    @patch('salt.modules.octopus_tentacle._get_exe_path',
+           MagicMock(return_value=EXE_PATH))
+    @patch('salt.modules.octopus_tentacle.get_config',
+           MagicMock(return_value=CONFIG_DICT))
+    def test_set_cert(self):
+        '''
+        Test - Generate a tentacle certificate for the provided instance.
+        '''
+        mock_cmd = MagicMock(return_value={'retcode': 0})
+        with patch.dict(octopus_tentacle.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertTrue(octopus_tentacle.set_cert())
+
+    @patch('salt.modules.octopus_tentacle._get_exe_path',
+           MagicMock(return_value=EXE_PATH))
+    @patch('salt.modules.octopus_tentacle.version_is_3_or_newer',
+           MagicMock(return_value=False))
+    @patch('salt.modules.octopus_tentacle.get_config',
+           MagicMock(return_value=CONFIG_DICT))
+    def test_set_squid(self):
+        '''
+        Test - Manage the SQUID of the provided instance.
+        '''
+        mock_cmd = MagicMock(return_value={'retcode': 0})
+        with patch.dict(octopus_tentacle.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertTrue(octopus_tentacle.set_squid())
+
+    @patch('salt.modules.octopus_tentacle._get_exe_path',
+           MagicMock(return_value=EXE_PATH))
+    @patch('salt.modules.octopus_tentacle.get_config',
+           MagicMock(return_value=CONFIG_DICT))
+    def test_set_trust(self):
+        '''
+        Test - Manage the server thumbprint trust of the provided instance.
+        '''
+        mock_cmd = MagicMock(return_value={'retcode': 0})
+        with patch.dict(octopus_tentacle.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertTrue(octopus_tentacle.set_trust('FFFEEEDDDCCCBBBAAA0001112233445566778899'))
+
+if __name__ == '__main__':
+    from integration import run_tests  # pylint: disable=import-error
+    run_tests(OctopusTentacleTestCase, needs_daemon=False)


### PR DESCRIPTION
### What does this PR do?

* PLEASE NOTE: I was unsure if this should be contributed to salt or salt-contrib. I can submit a new pull to salt if that makes more sense.
* Adds execution and state modules for [Octopus Deploy](https://octopus.com/) Tentacle client on Windows minions.
* Adds some execution module unit tests for the above.

### What issues does this PR fix or reference?

* None

### Previous Behavior

* Ability to manage Octopus Deploy Tentacle client on Windows minions did not previously exist.

### New Behavior

* Adds execution and state modules for Octopus Deploy Tentacle client on Windows minions.
* Adds some execution module unit tests for the above.

### Tests written?

Yes