### PR TITLE
Add logic to ec2_info.py to stop exceptions on non-EC2 systems

### DIFF
--- a/grains/ec2_info.py
+++ b/grains/ec2_info.py
@@ -15,6 +15,16 @@ import json
 LOG = logging.getLogger(__name__)
 
 
+def _on_ec2()
+    """
+    Call AWS via httplib. Require correct path.
+    Host: 169.254.169.254
+
+    """
+    conn = httplib.HTTPConnection("169.254.169.254", 80, timeout=0.1)
+    return bool(conn)
+
+
 def _call_aws(url):
     """
     Call AWS via httplib. Require correct path.
@@ -169,5 +179,9 @@ def ec2_instance_id():
 
 
 if __name__ == "__main__":
-    print ec2_info()
-    print ec2_instance_id()
+    if _on_ec2():
+        print ec2_info()
+        print ec2_instance_id()
+    else:
+        log.info("Not an EC2 instance, skipping")
+        print ''


### PR DESCRIPTION

We use salt in a heterogeneous environment (including EC2) we tend to see errors from the ec2_info grain when we run salt. I've followed the approach from ec2_tags.py and tweaked it to work for ec2_info.py.

```
[ERROR   ] Caught exception reading instance data
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/boto/utils.py", line 210, in retry_url
    r = opener.open(req, timeout=timeout)
  File "/usr/lib/python2.7/urllib2.py", line 404, in open
    response = self._open(req, data)
  File "/usr/lib/python2.7/urllib2.py", line 422, in _open
    '_open', req)
  File "/usr/lib/python2.7/urllib2.py", line 382, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.7/urllib2.py", line 1214, in http_open
    return self.do_open(httplib.HTTPConnection, req)
  File "/usr/lib/python2.7/urllib2.py", line 1184, in do_open
    raise URLError(err)
URLError: <urlopen error timed out>
[ERROR   ] Unable to read instance data, giving up
```