### PR TITLE
try except for _kmod_info(pci_data['driver'])

### DIFF
--- a/grains/hw_raid.py
+++ b/grains/hw_raid.py
@@ -92,10 +92,13 @@ def raid_info():
 
             # for detected cards append kernel module info
             if pci_data:
-                pci_data.update(_kmod_info(pci_data['driver']))
+                try:
+                    pci_data.update(_kmod_info(pci_data['driver']))
+                    return {'raidcontroller': pci_data}
 
-                return {'raidcontroller': pci_data}
-
+                except (KeyError):
+                    log.debug('No RAID driver found')
+                    return {'raidcontroller': pci_data}
             else:
                 log.debug('No RAID controllers detected')
 


### PR DESCRIPTION
Fails for me on old machines Dell 1950/2950 running Debian Wheezy 2950. Try/except to find driver.