### PR TITLE
fixes nested aws tags issue with salt compatibility

### DIFF
--- a/grains/ec2_tags.py
+++ b/grains/ec2_tags.py
@@ -122,7 +122,7 @@ def ec2_tags():
         tags = conn.get_all_tags(filters={'resource-type': 'instance',
                                           'resource-id': instance_id})
         for tag in tags:
-            ec2_tags[tag.name] = tag.value
+            ec2_tags[tag.name.replace(':','-')] = tag.value
     except Exception, e:
         log.error("Couldn't retrieve instance tags: %s", e)
         return None


### PR DESCRIPTION
If your aws resource tags have ':' within them, this becomes incredibly difficult to target once within saltstack. A simple resolution is to simply use '-'. Since AWS tags cannot be nested, this approach solves the grain targeting issues at the module level as well as at the top.sls level.