### PR TITLE
Add support for RAID via Serial Attached SCSI.

### DIFF
--- a/grains/hw_raid.py
+++ b/grains/hw_raid.py
@@ -80,7 +80,7 @@ def raid_info():
             hwinfo = subprocess.Popen('lspci -m'.split(), stdout=subprocess.PIPE)
 
             for line in hwinfo.stdout.readlines():
-                if 'RAID' in line:
+                if re.search('RAID|Serial Attached SCSI', line):
                     # sanitize the output and load it into a list
                     raw_fields = line.strip().split('"')
                     fields = [field for field in raw_fields if not (field == ' ' or field == '')]


### PR DESCRIPTION
Some RAID devices are appeared as "Serial Attached SCSI" in `lspci` output like The [FusionMPT SAS2](https://hwraid.le-vert.net/wiki/LSIFusionMPTSAS2) is a low-end card from LSI.

An example for the output:
```
# lspci | egrep "RAID|Serial Attached SCSI"
03:00.0 Serial Attached SCSI controller: LSI Logic / Symbios Logic SAS2004 PCI-Express Fusion-MPT SAS-2 [Spitfire] (rev 03)
```