### PR TITLE
ec2_info breaks on empty endpoint

### DIFF
--- a/grains/ec2_info.py
+++ b/grains/ec2_info.py
@@ -43,6 +43,8 @@ def _get_ec2_hostinfo(path=""):
             line = line.split("=")[0] + "/"
         if path == "instance-id/":
             return {'instance-id': line}
+        if len(line) == 0:
+            continue
         if line[-1] != "/":
             call_response = _call_aws("/latest/meta-data/{0}".format(path + line))
             call_response_data = call_response.read().decode('utf-8')


### PR DESCRIPTION
By default `events/maintenance/` is empty which makes `_get_ec2_hostinfo` to fail with the following error:

```
IndexError: string index out of range
```

