### PR TITLE
Update ec2_info grains to reflect changes to EC2 metadata

### DIFF
--- a/grains/ec2_info.py
+++ b/grains/ec2_info.py
@@ -43,6 +43,8 @@ def _get_ec2_hostinfo(path=""):
             line = line.split("=")[0] + "/"
         if path == "instance-id/":
             return {'instance-id': line}
+        if line == "":
+            return d
         if line[-1] != "/":
             call_response = _call_aws("/latest/meta-data/{0}".format(path + line))
             call_response_data = call_response.read().decode('utf-8')


### PR DESCRIPTION
Recent changes to EC2 metadata (version 2018-08-17) introduced new
subpath "events/maintenance/", which does not follow previous
convention of not having empty directories. This breaks ec2_info
grains.

This patch is to ignore empty subpath, so the rest of the grains
can be successfully parsed and loaded.