### PR TITLE
_get_ec2_hostinfo: skip empty lines

### DIFF
--- a/grains/ec2_info.py
+++ b/grains/ec2_info.py
@@ -39,6 +39,8 @@ def _get_ec2_hostinfo(path=""):
     resp_data = resp.read().decode('utf-8').strip()
     d = {}
     for line in resp_data.split("\n"):
+        if line == "":
+            continue
         if path == "public-keys/":
             line = line.split("=")[0] + "/"
         if path == "instance-id/":


### PR DESCRIPTION
I am seeing an empty reponse for
`/latest/meta-data/events/maintenance/`, which results in a `IndexError:
string index out of range` without this patch.