### PR TITLE
resolve crash and make more pythonic

### DIFF
--- a/grains/ec2_info.py
+++ b/grains/ec2_info.py
@@ -43,7 +43,7 @@ def _get_ec2_hostinfo(path=""):
             line = line.split("=")[0] + "/"
         if path == "instance-id/":
             return {'instance-id': line}
-        if line[-1] != "/":
+        if not line.endswith("/"):
             call_response = _call_aws("/latest/meta-data/{0}".format(path + line))
             call_response_data = call_response.read().decode('utf-8')
             # avoid setting empty grain


### PR DESCRIPTION
Experienced scenario
```
[CRITICAL] Failed to load grains defined in grain file ec2_info.ec2_info in function <function ec2_info at 0x7f8cdfc8bde8>, error:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 757, in grains
    ret = funcs[key]()
  File "/var/cache/salt/minion/extmods/grains/ec2_info.py", line 153, in ec2_info
    grains.update(_get_ec2_hostinfo())
  File "/var/cache/salt/minion/extmods/grains/ec2_info.py", line 69, in _get_ec2_hostinfo
    d[_dash_to_snake_case(line[:-1])] = _get_ec2_hostinfo(path + line)
  File "/var/cache/salt/minion/extmods/grains/ec2_info.py", line 69, in _get_ec2_hostinfo
    d[_dash_to_snake_case(line[:-1])] = _get_ec2_hostinfo(path + line)
  File "/var/cache/salt/minion/extmods/grains/ec2_info.py", line 46, in _get_ec2_hostinfo
    if line[-1] != "/":
IndexError: string index out of range
```

This corrects for that case