### PR TITLE
Skip exception when returning additional ec2_info

### DIFF
--- a/grains/ec2_info.py
+++ b/grains/ec2_info.py
@@ -103,6 +103,8 @@ def _get_ec2_additional():
         data = _snake_caseify_dict(data)
         data.update({'instance_identity': {'document': response_data}})
         return data
+    elif response.status == 404:
+        return {}
     else:
         raise BadStatusLine("Could not read EC2 metadata")
 


### PR DESCRIPTION
This change stops a non-fatal exception being raised by returning an empty dictionary instead. When the instance identity document does not exist cloud init will return a 404 response.