### PR TITLE
Add a couple more grains - vpc and nvme

### DIFF
--- a/grains/ec2_info.py
+++ b/grains/ec2_info.py
@@ -166,7 +166,7 @@ def _get_ec2_ebs_is_nvme():
     Determine if this instance mounts disks as nvme
     https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
     """
-    cmd = "lsblk | awk '{print $1}' | grep nvme"
+    cmd = "lsblk | awk '{print $1}' | grep -q nvme"
     
     return os.system(cmd) == 0
 

--- a/grains/ec2_info.py
+++ b/grains/ec2_info.py
@@ -167,9 +167,8 @@ def _get_ec2_ebs_is_nvme():
     https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
     """
     cmd = "lsblk | awk '{print $1}' | grep nvme"
-    x = os.system(cmd)
-
-    return x == 0
+    
+    return os.system(cmd) == 0
 
 def ec2_info():
     """


### PR DESCRIPTION
We are in the process of migrating from EC2 Classic to VPC. We've found a couple of small things have really helped us:

1. Adding an is_vpc grain, so that we can easily tell whether this instance is or is not in a VPC
2. Adding an `is_nvme_disk` grain so we can identify Nitro based instances which use /dev/nvme.. instead of /dev/x...

We're not massively wedded to the style I've built these grains in, and so if there are strong opinions on how this should be laid out, then we can happily modify them :)

We found the VPC one is available if you can get the metadata for the mac and then use that to parse the vpc, but adding `is_vpc` was so much easier :)