### PR TITLE
add py3 compatibility for external_ip grains

### DIFF
--- a/grains/external_ip.py
+++ b/grains/external_ip.py
@@ -39,7 +39,7 @@ def ext_ip():
     for url in check_ips:
         try:
             with contextlib.closing(urllib2.urlopen(url, timeout=3)) as req:
-                ip_ = req.read().strip()
+                ip_ = req.read().strip().decode('utf-8')
                 if not _ipv4_addr(ip_):
                     continue
             return {'external_ip': ip_}


### PR DESCRIPTION
With python3, ip_ return a bytes type object instead of a str. This make _ipv4_addr(ip_) test to always return False.

The decode option fix this behavior.